### PR TITLE
fix: #11 Tokens Column Parser Failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "saptest"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "criterion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib/lib.rs"
 
 [package]
 name = "saptest"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 authors = ["Keisuke K. Oshima <koshima789@gmail.com>"]
 description = "A library for testing Super Auto Pets teams."

--- a/src/lib/tests/test_parse_food.rs
+++ b/src/lib/tests/test_parse_food.rs
@@ -2,10 +2,13 @@ use itertools::Itertools;
 
 use crate::{
     db::{pack::Pack, record::FoodRecord},
-    wiki_scraper::parse_food::{
-        clean_link_text, get_effect_attack, get_effect_health, get_food_cost, get_largest_table,
-        get_random_n_effect, is_holdable_item, is_temp_single_use, is_turn_effect,
-        parse_one_food_entry, FoodTableCols,
+    wiki_scraper::{
+        common::get_largest_table,
+        parse_food::{
+            clean_link_text, get_effect_attack, get_effect_health, get_food_cost,
+            get_random_n_effect, is_holdable_item, is_temp_single_use, is_turn_effect,
+            parse_one_food_entry, FoodTableCols,
+        },
     },
     FoodName,
 };

--- a/src/lib/tests/test_parse_token.rs
+++ b/src/lib/tests/test_parse_token.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::{
     db::{pack::Pack, record::PetRecord},
     wiki_scraper::{
-        parse_food::get_largest_table,
+        common::get_largest_table,
         parse_tokens::{clean_token_block, parse_single_token, TokenTableCols},
     },
     PetName,
@@ -23,7 +23,7 @@ const TOKEN_TABLE: &str = "
 |{{IconSAP|Bee}}
 | colspan=\"3\" |1/1
 |Any [[Pets|Animal]] with {{IconSAP|Honey}} once it faints.
-|
+|-
 |}
 ";
 
@@ -222,6 +222,15 @@ fn test_parse_invalid_token_cols() {
 #[test]
 fn test_parse_token_cols() {
     let table = get_largest_table(TOKEN_TABLE).unwrap();
+    // Four blocks. Last one is end break. Only one real entry.
+    assert_eq!(table.len(), 4);
+    assert_eq!(
+        table
+            .iter()
+            .filter(|block| block.starts_with("\n|{{IconSAP"))
+            .count(),
+        1
+    );
     let cols = TokenTableCols::get_cols(&table).unwrap();
     assert_eq!(
         cols,

--- a/src/lib/wiki_scraper/parse_pet.rs
+++ b/src/lib/wiki_scraper/parse_pet.rs
@@ -254,8 +254,7 @@ pub fn parse_pet_info(url: &str) -> Result<Vec<PetRecord>, SAPTestError> {
     for block in response.split("\n\n") {
         // Update pets and continue if cannot.
         if let Err(error_msg) = parse_single_pet(block, &mut curr_tier, &mut pets) {
-            error!(target: "wiki_scraper", "{:?}", error_msg);
-            continue;
+            error!(target: "wiki_scraper", "{error_msg}")
         }
     }
     info!(target: "wiki_scraper", "Retrieved {} pets.", pets.len());

--- a/src/lib/wiki_scraper/parse_tokens.rs
+++ b/src/lib/wiki_scraper/parse_tokens.rs
@@ -1,15 +1,15 @@
 use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 use itertools::Itertools;
-use log::{info, warn};
+use log::{error, info, warn};
 
 use crate::{
     db::{pack::Pack, record::PetRecord},
     error::SAPTestError,
     regex_patterns::*,
     wiki_scraper::{
-        common::get_page_info,
-        parse_food::{clean_link_text, get_largest_table},
+        common::{get_largest_table, get_page_info},
+        parse_food::clean_link_text,
     },
     PetName,
 };
@@ -179,6 +179,7 @@ pub fn parse_single_token(
 
     Ok(())
 }
+
 /// Parse token info into a list of `Pet`s.
 pub fn parse_token_info(url: &str) -> Result<Vec<PetRecord>, SAPTestError> {
     let response = get_page_info(url)?;
@@ -188,14 +189,12 @@ pub fn parse_token_info(url: &str) -> Result<Vec<PetRecord>, SAPTestError> {
     let cols = TokenTableCols::get_cols(&table)?;
 
     for block in table
-        .get(2..)
-        .ok_or(SAPTestError::ParserFailure {
-            subject: "Token Cols".to_string(),
-            reason: "No largest table in token url content.".to_string(),
-        })?
         .iter()
+        .filter(|block| block.starts_with("\n|{{IconSAP"))
     {
-        parse_single_token(block, &cols, &mut pets)?;
+        if let Err(err) = parse_single_token(block, &cols, &mut pets) {
+            error!(target: "wiki_scraper", "{err}")
+        };
     }
 
     info!(target: "wiki_scraper", "Retrieved {} tokens.", pets.len());


### PR DESCRIPTION
Fixes #11.

* Changed `parse_single_token()` to warn on invalid entries instead of panic.
* Added filter to check block starting characters.
* Moved `get_largest_table()` to `wiki_scraper/common.rs`
* Bumped version to `v0.4.9`.