### PR TITLE
fix: #10 Incorrect Token Tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,20 +10,20 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -59,9 +59,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "cast"
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -227,9 +227,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -266,17 +266,23 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -314,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -334,9 +340,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -361,7 +367,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -372,9 +378,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -423,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -502,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
@@ -542,18 +548,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -642,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -653,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "ring"
@@ -718,15 +724,14 @@ name = "sap_examples"
 version = "0.1.0"
 dependencies = [
  "itertools",
- "saptest 0.4.6",
+ "saptest 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "saptest"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3339a780a7bef5ccec8c83a4c647e7f8b6bb9b00d59a49ea8ac3995a0bfb20a9"
+version = "0.4.9"
 dependencies = [
+ "criterion",
  "indexmap",
  "itertools",
  "lazy-regex",
@@ -749,8 +754,9 @@ dependencies = [
 [[package]]
 name = "saptest"
 version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceefd00d3af925ce2a35da25c065fbb86e35e91ef0a16a271f36603e0f89f92"
 dependencies = [
- "criterion",
  "indexmap",
  "itertools",
  "lazy-regex",
@@ -797,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -816,20 +822,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -838,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -869,6 +875,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,22 +896,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -924,9 +941,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -936,18 +953,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
 dependencies = [
  "indexmap",
  "serde",
@@ -958,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -1030,12 +1047,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -1047,9 +1063,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1057,24 +1073,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1082,28 +1098,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1170,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1185,51 +1201,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,14 +724,15 @@ name = "sap_examples"
 version = "0.1.0"
 dependencies = [
  "itertools",
- "saptest 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "saptest 0.4.9",
 ]
 
 [[package]]
 name = "saptest"
 version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceefd00d3af925ce2a35da25c065fbb86e35e91ef0a16a271f36603e0f89f92"
 dependencies = [
- "criterion",
  "indexmap",
  "itertools",
  "lazy-regex",
@@ -753,10 +754,9 @@ dependencies = [
 
 [[package]]
 name = "saptest"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceefd00d3af925ce2a35da25c065fbb86e35e91ef0a16a271f36603e0f89f92"
+version = "0.4.10"
 dependencies = [
+ "criterion",
  "indexmap",
  "itertools",
  "lazy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib/lib.rs"
 
 [package]
 name = "saptest"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 authors = ["Keisuke K. Oshima <koshima789@gmail.com>"]
 description = "A library for testing Super Auto Pets teams."

--- a/src/lib/db/mod.rs
+++ b/src/lib/db/mod.rs
@@ -52,6 +52,7 @@
 //!     lvl INTEGER NOT NULL,
 //!     cost INTEGER NOT NULL,
 //!     img_url TEXT,
+//!     is_token BOOLEAN NOT NULL,
 //!     CONSTRAINT unq UNIQUE (name, pack, lvl)
 //! );
 //! ```
@@ -87,6 +88,8 @@
 //!     * Cost of pet.
 //! * `img_url`
 //!     * Current image url displayed on page.
+//! * `is_token`
+//!     * Is current pet a [token](https://superautopets.fandom.com/wiki/Tokens)?
 //!
 //! #### Foods
 //! Food records.

--- a/src/lib/db/record.rs
+++ b/src/lib/db/record.rs
@@ -132,4 +132,6 @@ pub struct PetRecord {
     pub cost: usize,
     /// Most recent image url.
     pub img_url: String,
+    /// Is pet a token?
+    pub is_token: bool,
 }

--- a/src/lib/db/setup.rs
+++ b/src/lib/db/setup.rs
@@ -99,6 +99,7 @@ impl SapDB {
                 lvl INTEGER NOT NULL,
                 cost INTEGER NOT NULL,
                 img_url TEXT,
+                is_token BOOLEAN NOT NULL,
                 CONSTRAINT unq UNIQUE (name, pack, lvl)
             );
             CREATE TABLE IF NOT EXISTS foods (
@@ -202,9 +203,9 @@ impl SapDB {
             INSERT INTO pets (
                 name, tier, attack, health, pack,
                 effect_trigger, effect, effect_atk, effect_health, n_triggers, temp_effect,
-                lvl, cost, img_url
+                lvl, cost, img_url, is_token
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             ON CONFLICT(name, pack, lvl) DO UPDATE SET
                 tier = ?2,
                 attack = ?3,
@@ -215,7 +216,8 @@ impl SapDB {
                 effect_health = ?9,
                 n_triggers = ?10,
                 temp_effect = ?11,
-                img_url = ?14
+                img_url = ?14,
+                is_token = ?15
             WHERE
                 tier != ?2 OR
                 attack != ?3 OR
@@ -263,6 +265,7 @@ impl SapDB {
                     &pet.lvl.to_string(),
                     &pet.cost.to_string(),
                     &pet.img_url.to_string(),
+                    &pet.is_token.to_string(),
                 ],
             )?;
             n_rows_updated += n_rows;

--- a/src/lib/db/utils.rs
+++ b/src/lib/db/utils.rs
@@ -16,6 +16,7 @@ impl TryFrom<&Row<'_>> for PetRecord {
         let pet_name: String = pet_row.get(1)?;
         let pack: String = pet_row.get(5)?;
         let is_temp_effect_str: String = pet_row.get(11)?;
+        let is_token: String = pet_row.get(15)?;
         Ok(PetRecord {
             name: PetName::from_str(&pet_name)?,
             tier: pet_row.get(2)?,
@@ -31,6 +32,7 @@ impl TryFrom<&Row<'_>> for PetRecord {
             lvl: pet_row.get(12)?,
             cost: pet_row.get(13)?,
             img_url: pet_row.get(14)?,
+            is_token: is_token == *"true",
         })
     }
 }

--- a/src/lib/pets/effects.rs
+++ b/src/lib/pets/effects.rs
@@ -2150,8 +2150,9 @@ impl TryFrom<PetRecord> for Vec<Effect> {
                 position: Position::OnSelf,
                 action: Action::Multiple(vec![
                     Action::Summon(SummonType::QueryPet(
-                        "SELECT * FROM pets WHERE effect_trigger = ? AND lvl = ?".to_string(),
-                        vec!["Faint".to_string(), 1.to_string()],
+                        "SELECT * FROM pets WHERE effect_trigger = ? AND lvl = ? AND is_token = ?"
+                            .to_string(),
+                        vec!["Faint".to_string(), 1.to_string(), false.to_string()],
                         None
                     ));
                     record.lvl
@@ -2198,8 +2199,14 @@ impl TryFrom<PetRecord> for Vec<Effect> {
                 target: Target::Friend,
                 position: Position::OnSelf,
                 action: Action::Summon(SummonType::QueryPet(
-                    "SELECT * FROM pets WHERE lvl = ? AND tier = ? AND name != ?".to_string(),
-                    vec![1.to_string(), 1.to_string(), "Sloth".to_string()],
+                    "SELECT * FROM pets WHERE lvl = ? AND tier = ? AND name != ? AND is_token = ?"
+                        .to_string(),
+                    vec![
+                        1.to_string(),
+                        1.to_string(),
+                        "Sloth".to_string(),
+                        false.to_string(),
+                    ],
                     Some(effect_stats),
                 )),
                 uses: None,

--- a/src/lib/shop/store.rs
+++ b/src/lib/shop/store.rs
@@ -537,7 +537,7 @@ impl Shop {
                 let stmt = query
                     .as_sql()
                     .map(|mut sql| {
-                        sql.push_str("AND name != 'Sloth'");
+                        sql.push_str("AND name != 'Sloth' AND is_token = 'false'");
                         sql
                     })
                     .unwrap();

--- a/src/lib/tests/test_parse_pet.rs
+++ b/src/lib/tests/test_parse_pet.rs
@@ -133,6 +133,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
         PetRecord {
             name: PetName::Mammoth,
@@ -151,6 +152,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
         PetRecord {
             name: PetName::Mammoth,
@@ -169,6 +171,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
         PetRecord {
             name: PetName::Mammoth,
@@ -187,6 +190,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
         PetRecord {
             name: PetName::Mammoth,
@@ -205,6 +209,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
         PetRecord {
             name: PetName::Mammoth,
@@ -223,6 +228,7 @@ fn test_create_pet_record() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/fe/Mammoth_Icon.png",
             ),
+            is_token: false,
         },
     ];
     assert_eq!(

--- a/src/lib/tests/test_parse_token.rs
+++ b/src/lib/tests/test_parse_token.rs
@@ -61,7 +61,7 @@ fn test_parse_single_token_explicit_lvl_stats() {
     let exp_pets = [
         PetRecord {
             name: PetName::Bus,
-            tier: 0,
+            tier: 1,
             attack: 5,
             health: 5,
             pack: Pack::Unknown,
@@ -76,10 +76,11 @@ fn test_parse_single_token_explicit_lvl_stats() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/f0/Bus_Icon.png",
             ),
+            is_token: true,
         },
         PetRecord {
             name: PetName::Bus,
-            tier: 0,
+            tier: 1,
             attack: 10,
             health: 10,
             pack: Pack::Unknown,
@@ -94,10 +95,11 @@ fn test_parse_single_token_explicit_lvl_stats() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/f0/Bus_Icon.png",
             ),
+            is_token: true,
         },
         PetRecord {
             name: PetName::Bus,
-            tier: 0,
+            tier: 1,
             attack: 15,
             health: 15,
             pack: Pack::Unknown,
@@ -112,6 +114,7 @@ fn test_parse_single_token_explicit_lvl_stats() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/f/f0/Bus_Icon.png",
             ),
+            is_token: true,
         },
     ];
     assert_eq!(pets, exp_pets)
@@ -135,7 +138,7 @@ fn test_parse_single_token_colspan() {
     let exp_pets = [
         PetRecord {
             name: PetName::Butterfly,
-            tier: 0,
+            tier: 1,
             attack: 1,
             health: 1,
             pack: Pack::Unknown,
@@ -152,10 +155,11 @@ fn test_parse_single_token_colspan() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/3/3d/Butterfly_Icon.png",
             ),
+            is_token: true,
         },
         PetRecord {
             name: PetName::Butterfly,
-            tier: 0,
+            tier: 1,
             attack: 1,
             health: 1,
             pack: Pack::Unknown,
@@ -172,10 +176,11 @@ fn test_parse_single_token_colspan() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/3/3d/Butterfly_Icon.png",
             ),
+            is_token: true,
         },
         PetRecord {
             name: PetName::Butterfly,
-            tier: 0,
+            tier: 1,
             attack: 1,
             health: 1,
             pack: Pack::Unknown,
@@ -192,6 +197,7 @@ fn test_parse_single_token_colspan() {
             img_url: String::from(
                 "https://static.wikia.nocookie.net/superautopets/images/3/3d/Butterfly_Icon.png",
             ),
+            is_token: true,
         },
     ];
 

--- a/src/lib/tests/test_pet.rs
+++ b/src/lib/tests/test_pet.rs
@@ -217,7 +217,7 @@ fn create_pet_token() {
         Pet {
             id: None,
             name: PetName::Bee,
-            tier: 0,
+            tier: 1,
             stats: Statistics {
                 attack: 50,
                 health: 50,

--- a/src/lib/tests/test_team_t5.rs
+++ b/src/lib/tests/test_team_t5.rs
@@ -66,6 +66,37 @@ fn test_battle_rhino_team() {
 }
 
 #[test]
+fn test_battle_rhino_against_token_team() {
+    let bee = Pet::new(
+        PetName::Bee,
+        Some(Statistics {
+            attack: 50,
+            health: 50,
+        }),
+        1,
+    )
+    .unwrap();
+    let duck = Pet::try_from(PetName::Duck).unwrap();
+
+    let rhino = Pet::try_from(PetName::Rhino).unwrap();
+
+    let mut t1 = Team::new(&[Some(duck), Some(bee)], 5).unwrap();
+    let mut t2 = Team::new(&[Some(rhino)], 5).unwrap();
+
+    t1.fight(&mut t2).unwrap();
+
+    // Rhino does 8 damage to Bee because tier 1.
+    assert_eq!(t1.first().unwrap().read().unwrap().tier, 1);
+    assert_eq!(
+        t1.first().unwrap().read().unwrap().stats,
+        Statistics {
+            attack: 50,
+            health: 42
+        }
+    );
+}
+
+#[test]
 fn test_battle_chili_rhino() {
     const RHINO_DMG: Statistics = Statistics {
         attack: 0,

--- a/src/lib/wiki_scraper/parse_pet.rs
+++ b/src/lib/wiki_scraper/parse_pet.rs
@@ -236,6 +236,7 @@ pub fn parse_single_pet(
                     lvl: lvl + 1,
                     cost: DEFAULT_PET_COST,
                     img_url: url.clone(),
+                    is_token: false,
                 };
 
                 pets.push(pet)

--- a/src/lib/wiki_scraper/parse_tokens.rs
+++ b/src/lib/wiki_scraper/parse_tokens.rs
@@ -155,7 +155,8 @@ pub fn parse_single_token(
             {
                 pets.push(PetRecord {
                     name: PetName::from_str(name)?,
-                    tier: 0,
+                    // All tokens treated as tier 1.
+                    tier: 1,
                     attack,
                     health,
                     pack: Pack::Unknown,
@@ -168,6 +169,7 @@ pub fn parse_single_token(
                     lvl: lvl + 1,
                     cost: DEFAULT_TOKEN_COST,
                     img_url: url.clone(),
+                    is_token: true,
                 })
             } else {
                 warn!("Failed to parse stats for {name} from string {stats}.")


### PR DESCRIPTION
Fixes #10:
* Adds `is_token` field to `PetRecord`.
* Changed token tier to always be 1 so effects relying on tier number are correct (ex. Rhino).
* Bumped version to v.0.4.10